### PR TITLE
Attempt to support properties

### DIFF
--- a/src/ImageGeoms.jl
+++ b/src/ImageGeoms.jl
@@ -15,7 +15,6 @@ include("imresize.jl")
 include("makemask.jl")
 include("mask.jl")
 
-# excluded because the way it modifies getproperty causes type instability
-#include("property.jl")
+#include("property.jl") # exclude due to type inference issues
 
 end # module

--- a/test/core.jl
+++ b/test/core.jl
@@ -45,7 +45,7 @@ end
     show(isinteractive() ? stdout : devnull, MIME("text/plain"), ig)
 
     for f in (zeros, ones, falses, trues)
-        @test f(ig.dims) == @inferred f(ig)
+        @test f(ig.dims) == (@inferred f(ig))
     end
     @test ndims(ig) == 2
     @test size(ig) == dims

--- a/test/helper.jl
+++ b/test/helper.jl
@@ -1,0 +1,6 @@
+# helper.jl
+# utilities used in multiple test files
+
+macro NOTinferred(ex) # flag where @inferred fails
+    :($(esc(ex)))
+end

--- a/test/property.jl
+++ b/test/property.jl
@@ -1,37 +1,38 @@
 # tests for properties
 
 using ImageGeoms
+using FillArrays: Trues, Falses, Zeros, Ones
 using Test: @test, @testset, @test_throws, @inferred
 
 # test 2D properties
 function image_geom_test2(ig::ImageGeom)
-    ig.dims
-    ig.deltas
-    ig.offsets
+    @test ig.dims isa Tuple
+    @test ig.deltas isa Tuple
+    @test ig.offsets isa Tuple
 
-    ig.dim
-    ig.x
-    ig.y
-    ig.wx
-    ig.wy
-    ig.xg
-    ig.yg
-    ig.fovs
-    ig.np
+    @test ig.dim isa Tuple
+    @test ig.x isa AbstractVector
+    @test ig.y isa AbstractVector
+    @test ig.wx isa Number
+    @test ig.wy isa Number
+    @test ig.xg isa AbstractArray
+    @test ig.yg isa AbstractArray
+    @test ig.fovs isa Tuple
+    @test ig.np isa Int
 #   ig.mask_outline
-    ig.ones
-    ig.zeros
-    ig.u
-    ig.v
-    ig.ug
-    ig.vg
+    @test ig.ones isa Ones
+    @test ig.zeros isa Zeros
+    @test ig.u isa AbstractVector
+    @test ig.v isa AbstractVector
+    @test ig.ug isa AbstractArray
+    @test ig.vg isa AbstractArray
 #   ig.fg
 
     @test ig.shape(vec(ig.ones)) == ig.ones
     @test ig.embed(ig.ones[ig.mask]) == ig.mask
     @test ig.maskit(ig.ones) == ones(ig.np)
 #   @inferred # todo
-    ig.unitv()
+    @inferred ig.unitv()
     ig.unitv(j=4)
     ig.unitv(i=ntuple(i->1, length(ig.dim)))
     ig.unitv(c=ntuple(i->0, length(ig.dim)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test: @test, @testset, detect_ambiguities
 using ImageGeoms
 
+include("helper.jl")
+
 include("core.jl")
 include("imresize.jl")
 include("makemask.jl")


### PR DESCRIPTION
This was an attempt to support properties like `ig.nx` to facilitate evolving MIRT.jl to use this version.
However, it ran into type inference issues somehow.
I still plan to merge it because it did some useful clean up and setting the stage for possible future efforts along these lines if needed.  There are no actual changes so no version bump.