### PR TITLE
LazyGrid compat 0.4, deprecate `zero(ig)`, Aqua tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageGeoms"
 uuid = "9ee76f2b-840d-4475-b6d6-e485c9297852"
-authors = ["Jeff Fessler <fessler@umich.edu>"]
-version = "0.5.1"
+authors = ["Jeff Fessler <fessler@umich.edu>" and contributors]
+version = "0.6"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -10,6 +10,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 FillArrays = "0.12, 0.13"
-LazyGrids = "0.2, 0.3"
+LazyGrids = "0.4"
 Requires = "1.3"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageGeoms"
 uuid = "9ee76f2b-840d-4475-b6d6-e485c9297852"
-authors = ["Jeff Fessler <fessler@umich.edu>" and contributors]
+authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
 version = "0.6"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 https://github.com/JuliaImageRecon/ImageGeoms.jl
 
+[![docs-stable][docs-stable-img]][docs-stable-url]
+[![docs-dev][docs-dev-img]][docs-dev-url]
 [![action status][action-img]][action-url]
 [![pkgeval status][pkgeval-img]][pkgeval-url]
 [![codecov][codecov-img]][codecov-url]
 [![license][license-img]][license-url]
-[![docs-stable][docs-stable-img]][docs-stable-url]
-[![docs-dev][docs-dev-img]][docs-dev-url]
+[![Aqua QA][aqua-img]][aqua-url]
 [![code-style][code-blue-img]][code-blue-url]
 
 This Julia package exports the type `ImageGeom`
@@ -79,3 +80,5 @@ Tested with Julia ≥ 1.6.
 [docs-dev-url]: https://JuliaImageRecon.github.io/ImageGeoms.jl/dev
 [license-img]: http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat
 [license-url]: LICENSE
+[aqua-img]: https://img.shields.io/badge/Aqua.jl-%F0%9F%8C%A2-aqua.svg
+[aqua-url]: https://github.com/JuliaTesting/Aqua.jl

--- a/archive/property.jl
+++ b/archive/property.jl
@@ -149,8 +149,8 @@ image_geom_fun0 = Dict([
     (:ones, ig -> ones(ig)),
 
     (:dx, ig -> ig.deltas[1]),
-    (:dy, ig -> ig.ndim ≥ 2 ? ig.deltas[2] : zero(ig)),
-    (:dz, ig -> ig.ndim ≥ 3 ? ig.deltas[3] : zero(ig)),
+    (:dy, ig -> ig.ndim ≥ 2 ? ig.deltas[2] : zero(ig.deltas[1])),
+    (:dz, ig -> ig.ndim ≥ 3 ? ig.deltas[3] : zero(ig.deltas[1])),
 
     (:offset_x, ig -> ig.offsets[1]),
     (:offset_y, ig -> ig.ndim ≥ 2 ? ig.offsets[2] : Float32(0)),

--- a/src/core.jl
+++ b/src/core.jl
@@ -40,7 +40,7 @@ struct ImageGeom{D, S <: NTuple{D,RealU}, M <: AbstractArray{Bool,D}}
             S <: NTuple{D,RealU}, # i.e., Union{Real,Unitful.Length}
             M <: AbstractArray{Bool,D},
         }
-        any(<=(zero(Int)), dims) && throw("dims must be positive")
+        any(<=(0), dims) && throw("dims must be positive")
         any(iszero, deltas) && throw("deltas must be nonzero")
         size(mask) == dims ||
             throw(DimensionMismatch("mask size $(size(mask)) vs dims $dims"))
@@ -156,10 +156,10 @@ Base.ones(ig::ImageGeom) = ones(Float32, ig)
 Base.trues(ig::ImageGeom) = Trues(ig.dims...)
 Base.falses(ig::ImageGeom) = Falses(ig.dims...)
 
-Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,Real}} = zero(Float32)
-Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,Any}} = zero(Int32) # alert!
-Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,T}} where {T <: Number} = zero(T)
-Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,T}} where {T <: Real} = zero(T)
+#Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,Real}} = zero(Float32)
+#Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,Any}} = zero(Int32) # alert!
+#Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,T}} where {T <: Number} = zero(T)
+#Base.zero(ig::ImageGeom{D,S}) where {D, S <: NTuple{D,T}} where {T <: Real} = zero(T)
 
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 MIRTjim = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -6,4 +7,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-FillArrays = "0.12"
+FillArrays = "0.13"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,8 @@
+using ImageGeoms
+import Aqua
+using Test: @testset
+
+@testset "aqua" begin
+    # todo: ambiguities in FillArrays
+    Aqua.test_all(ImageGeoms, ambiguities=false)
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -52,10 +52,10 @@ end
     @test size(ig,1) == dims[1]
 
     # _zero tests
-    @test zero(ImageGeom((2,3), (3.0,4.0), (0,0))) === zero(Float64)
-    @test zero(ImageGeom((2,3), (3.0,4.0f0), (0,0))) === zero(Float32)
-    @test zero(ImageGeom((2,3), (3m,4.0), (0,0))) === zero(Int32) # alert
-    @test zero(ImageGeom((2,3), (3.0m,4.0m), (0,0))) === zero(0.0m)
+#   @test zero(ImageGeom((2,3), (3.0,4.0), (0,0))) === zero(Float64)
+#   @test zero(ImageGeom((2,3), (3.0,4.0f0), (0,0))) === zero(Float32)
+#   @test zero(ImageGeom((2,3), (3m,4.0), (0,0))) === zero(Int32) # alert
+#   @test zero(ImageGeom((2,3), (3.0m,4.0m), (0,0))) === zero(0.0m)
 
     ig_down = @inferred downsample(ig, (2,2))
     ig_over = @inferred oversample(ig_down, (2,2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@
 using Test: @test, @testset, detect_ambiguities
 using ImageGeoms
 
+include("aqua.jl")
 include("helper.jl")
 
 include("core.jl")


### PR DESCRIPTION
v0.4 of `LazyGrid` is needed to handle `StepRangeLen` properly.
Aqua complained about `zero(ig)` and it is never used anyway, so removed.
Aqua testing incomplete due to method ambiguities in `FillArrays` v0.13.2.