### PR TITLE
Fix type of `axes` via `_offset`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageGeoms"
 uuid = "9ee76f2b-840d-4475-b6d6-e485c9297852"
 authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
-version = "0.6"
+version = "0.7"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/core.jl
+++ b/src/core.jl
@@ -229,7 +229,8 @@ end
 
 
 # spatial axes
-_center(n::Int, offset::Real) = (n - 1)/2 + offset
+_center(n::Int, offset::Toffset) where {Toffset <: Real} =
+    Toffset((n - 1)/2 + offset) # maintain type of offset
 _axis(n::Int, Δ::RealU, offset::Real) = ((0:n-1) .- _center(n, offset)) * Δ
 axis(ig::ImageGeom{D}, d::Int) where D =
     _axis(ig.dims[d], ig.deltas[d], ig.offsets[d])


### PR DESCRIPTION
Since `offsets` are fixed to `Float32` now, there is no need to have `Float64` for the `axes`.
If someone ever needs finer precision axes, then `offset` type should be made user-selectable.