### PR TITLE
Use CODECOV_TOKEN; full Aqua test (even ambiguities now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,33 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4
+
 #     - name: "Set up Julia"
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
+
+      - name: Cache artifacts
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+
 #     - name: "Unit Test"
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+
 #     - name: "Cover"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:
           file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -3,6 +3,5 @@ import Aqua
 using Test: @testset
 
 @testset "aqua" begin
-    # todo: ambiguities in FillArrays
-    Aqua.test_all(ImageGeoms, ambiguities=false)
+    Aqua.test_all(ImageGeoms)
 end


### PR DESCRIPTION
Using the CODECOV_TOKEN that I just added at the organization level, this should ensure codecov runs properly.